### PR TITLE
.GITIGNORE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+./ApiNode/node_modules


### PR DESCRIPTION
Colocar o node_modules no gitignore, quando alguem baixar o repositório é só rodar npm install